### PR TITLE
Add support, FAQ and volunteer info

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,18 +16,30 @@
       <a href="calendar.html">Events</a>
       <a href="interest.html">Get Involved</a>
       <a href="members.html">Members</a>
+      <a href="faq.html">FAQ</a>
+      <a href="shop.html">Shop</a>
     </nav>
   </header>
 
   <main>
     <section>
-      <h2>What We Do</h2>
-      <p>ReDelicious is a food lab co-op transforming food waste into delicious, sustainable, and educational experiences. We host fermentation workshops, community feasts, and mutual aid events throughout DC.</p>
+      <h2>ReDelicious DC</h2>
+      <p>We Turn Food Waste Into Delicious Community. Every Sunday we gather to cook, preserve, redistribute and forage for good food. All are welcome and the food is free.</p>
+    </section>
+
+    <section>
+      <h2>History of ReDelicious</h2>
+      <p>Check out our <a href="https://redelish.us/newsletters" target="_blank">Newsletters Archive</a> to see how we've grown.</p>
+    </section>
+
+    <section>
+      <h2>What is ReDelicious?</h2>
+      <p>We’re a worker cooperative of local foragers, mushroom growers and food lovers founded in 2022. Each week we divert and redistribute food that would otherwise go to waste from farmers markets and local businesses.</p>
+      <p>We invest in a kitchen lab and culture library to learn about food preservation, fermentation and ecology while building a culture of abundance.</p>
     </section>
   </main>
 
   <footer>
     <p>© 2025 ReDelicious Co-op</p>
   </footer>
-</body>
-</html>
+</body></html>

--- a/faq.html
+++ b/faq.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ReDelicious – FAQ</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>FAQ</h1>
+    <img src="ReDLogo6-25.svg" alt="ReDelicious logo" class="logo" />
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About Us</a>
+      <a href="calendar.html">Events</a>
+      <a href="interest.html">Get Involved</a>
+      <a href="members.html">Members</a>
+      <a href="faq.html">FAQ</a>
+      <a href="shop.html">Shop</a>
+    </nav>
+  </header>
+
+  <main>
+    <section>
+      <h2>Why are we a cooperative, not a nonprofit?</h2>
+      <p>We believe in economic democracy—having workers own and control a business together. We don't sell food and any money we receive goes back into labor, fun ingredients, and shared assets. Our co-op structure lets us build sustainable and circular economies rooted in collective wealth.</p>
+    </section>
+
+    <section>
+      <h2>Where are we going from here?</h2>
+      <p>We hope to expand the region's feeding capacity with fruit and nut trees, mushroom logs, and eventually a public kitchen lab and cafe space in DC. We want to connect big ideas to real lives through food.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,13 +16,22 @@
       <a href="calendar.html">Events</a>
       <a href="interest.html">Get Involved</a>
       <a href="members.html">Members</a>
+      <a href="faq.html">FAQ</a>
+      <a href="shop.html">Shop</a>
     </nav>
   </header>
 
   <main>
+    <p class="tagline">Free food, on a farm, every Sunday</p>
     <section>
       <h2>What We Do</h2>
       <p>ReDelicious is a food lab co-op transforming food waste into delicious, sustainable, and educational experiences. We host fermentation workshops, community feasts, and mutual aid events throughout DC.</p>
+    </section>
+    <section>
+      <h2>Support Us</h2>
+      <p>If you like what we do, consider supporting us.</p>
+      <p>Patreon: <a href="https://redelish.us/patreon" target="_blank">redelish.us/patreon</a></p>
+      <p>Venmo: <a href="https://venmo.com/redeliciousdc" target="_blank">@redeliciousdc</a></p>
     </section>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
   <header>
     <h1>ReDelicious</h1>
     <img src="ReDLogo6-25.svg" alt="ReDelicious logo" class="logo" />
-    <p>DC’s Food Lab Co-op:</p>
+    <p>DC’s Food Lab Co-op</p>
+    <p>turning food waste into delicious community</p>
+    
     <nav>
       <a href="index.html">Home</a>
       <a href="about.html">About Us</a>
@@ -26,13 +28,21 @@
     <section>
       <h2>What We Do</h2>
       <p>ReDelicious is a food lab co-op transforming food waste into delicious, sustainable, and educational experiences. We host fermentation workshops, community feasts, and mutual aid events throughout DC.</p>
+      <p>Every Sunday, we gather and build community through cooking, preserving, redistributing, and foraging for delicious food. All are welcome and the food is free.</p>
+     <h2>History of ReDelicious</h2>
+     <p>ReDelicious was started in 2022 blah blah pickle dreamz more 2 come.</p>
+
     </section>
+<<<<<<< HEAD
     <section>
       <h2>Support Us</h2>
       <p>If you like what we do, consider supporting us.</p>
       <p>Patreon: <a href="https://redelish.us/patreon" target="_blank">redelish.us/patreon</a></p>
       <p>Venmo: <a href="https://venmo.com/redeliciousdc" target="_blank">@redeliciousdc</a></p>
     </section>
+=======
+
+>>>>>>> origin/main
   </main>
 
   <footer>

--- a/interest.html
+++ b/interest.html
@@ -13,12 +13,16 @@
       <a href="index.html">Home</a>
       <a href="about.html">About Us</a>
       <a href="calendar.html">Events</a>
-      <a href="interest.html">Join Us</a>
+      <a href="interest.html">Get Involved</a>
       <a href="members.html">Members</a>
+      <a href="faq.html">FAQ</a>
+      <a href="shop.html">Shop</a>
     </nav>
   </header>
 
   <main>
+    <p>Feel free to drop by at 3pm to help set up or stay late to help do the dishes. Join the list (<a href="http://redelish.us/hello" target="_blank">redelish.us/hello</a>) to see what we're up to lately. If you have bigger ideas or would like a response, email <a href="mailto:redeliciouscoop@gmail.com">redeliciouscoop@gmail.com</a>.</p>
+
     <form action="https://formspree.io/f/YOUR_ID" method="POST">
       <label>Name:<br><input type="text" name="name" required></label><br><br>
       <label>Email:<br><input type="email" name="email" required></label><br><br>

--- a/members.html
+++ b/members.html
@@ -13,8 +13,10 @@
       <a href="index.html">Home</a>
       <a href="about.html">About Us</a>
       <a href="calendar.html">Events</a>
-      <a href="interest.html">Join Us</a>
+      <a href="interest.html">Get Involved</a>
       <a href="members.html">Members</a>
+      <a href="faq.html">FAQ</a>
+      <a href="shop.html">Shop</a>
     </nav>
   </header>
 

--- a/shop.html
+++ b/shop.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>ReDelicious – Events</title>
+  <title>ReDelicious – Shop</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <header>
-    <h1>Upcoming Events</h1>
+    <h1>Shop</h1>
     <img src="ReDLogo6-25.svg" alt="ReDelicious logo" class="logo" />
     <nav>
       <a href="index.html">Home</a>
@@ -21,7 +21,7 @@
   </header>
 
   <main>
-    <iframe src="https://calendar.google.com/calendar/embed?src=1b505a980c0444a41f2399276068d513a66156da379165a635d0ed68875b5cad%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    <p>Under construction - Coming soon</p>
   </main>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -39,6 +39,12 @@ nav a:hover {
   color: #c1ff00;
 }
 
+.tagline {
+  font-size: 1.5em;
+  font-weight: bold;
+  margin: 1em 0;
+}
+
 main {
   padding: 2em;
   max-width: 800px;


### PR DESCRIPTION
## Summary
- add tagline and support links on home page
- expand About page with cooperative info and history
- describe volunteer info on Get Involved page
- sync navigation across pages and add FAQ/Shop pages
- style tagline in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a196123d88323a8e3d2798bd60626